### PR TITLE
Fix some bugs

### DIFF
--- a/cdi-features-deployment/src/main/java/io/github/jonasrutishauser/cdi/features/deployment/CdiFeaturesExtensionProcessor.java
+++ b/cdi-features-deployment/src/main/java/io/github/jonasrutishauser/cdi/features/deployment/CdiFeaturesExtensionProcessor.java
@@ -80,7 +80,7 @@ public class CdiFeaturesExtensionProcessor {
                 classNamePrefix = classNamePrefix.substring(0, classNamePrefix.indexOf('<'));
             }
             String instanceTypeLiteralName = classNamePrefix + "$$instanceTypeLiteral$$"
-                    + counter.compute(classNamePrefix, (key, value) -> value == null ? 0 : value++);
+                    + counter.compute(classNamePrefix, (key, value) -> value == null ? 0 : ++value);
             ClassCreator.builder().classOutput(classGizmoAdaptor).className(instanceTypeLiteralName)
                     .signature(SignatureBuilder.forClass()
                             .setSuperClass(toGizmo(ParameterizedType.create(TypeLiteral.class, instanceType))))

--- a/cdi-features-deployment/src/test/java/io/github/jonasrutishauser/cdi/features/deployment/AlwaysFeature.java
+++ b/cdi-features-deployment/src/test/java/io/github/jonasrutishauser/cdi/features/deployment/AlwaysFeature.java
@@ -1,0 +1,19 @@
+package io.github.jonasrutishauser.cdi.features.deployment;
+
+import io.github.jonasrutishauser.cdi.features.Feature;
+import io.github.jonasrutishauser.cdi.features.ThrowableSelector;
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
+@Feature
+class AlwaysFeature implements GenericSampleFeature<StringBuffer>, ThrowableSelector {
+    @Override
+    public StringBuffer test() {
+        return new StringBuffer("always");
+    }
+
+    @Override
+    public void valid() {
+        // should always be valid
+    }
+}

--- a/cdi-features-deployment/src/test/java/io/github/jonasrutishauser/cdi/features/deployment/DefaultNotAFeature.java
+++ b/cdi-features-deployment/src/test/java/io/github/jonasrutishauser/cdi/features/deployment/DefaultNotAFeature.java
@@ -1,0 +1,11 @@
+package io.github.jonasrutishauser.cdi.features.deployment;
+
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
+class DefaultNotAFeature implements NotAFeature {
+    @Override
+    public CharSequence test() {
+        return "default";
+    }
+}

--- a/cdi-features-deployment/src/test/java/io/github/jonasrutishauser/cdi/features/deployment/GenericSampleFeature.java
+++ b/cdi-features-deployment/src/test/java/io/github/jonasrutishauser/cdi/features/deployment/GenericSampleFeature.java
@@ -1,5 +1,5 @@
 package io.github.jonasrutishauser.cdi.features.deployment;
 
-interface GenericSampleFeature<T extends CharSequence> {
+interface GenericSampleFeature<T extends CharSequence> extends NotAFeature {
     T test();
 }

--- a/cdi-features-deployment/src/test/java/io/github/jonasrutishauser/cdi/features/deployment/NeverFeature.java
+++ b/cdi-features-deployment/src/test/java/io/github/jonasrutishauser/cdi/features/deployment/NeverFeature.java
@@ -1,0 +1,22 @@
+package io.github.jonasrutishauser.cdi.features.deployment;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import io.github.jonasrutishauser.cdi.features.ContextualSelector;
+import io.github.jonasrutishauser.cdi.features.Feature;
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
+@Feature(selector = NeverSelector.class)
+@SuppressWarnings("rawtypes")
+class NeverFeature implements GenericSampleFeature<StringBuilder>, ContextualSelector {
+    @Override
+    public StringBuilder test() {
+        return fail("should not be called");
+    }
+
+    @Override
+    public boolean selected(Context context) {
+        return false;
+    }
+}

--- a/cdi-features-deployment/src/test/java/io/github/jonasrutishauser/cdi/features/deployment/NotAFeature.java
+++ b/cdi-features-deployment/src/test/java/io/github/jonasrutishauser/cdi/features/deployment/NotAFeature.java
@@ -1,0 +1,5 @@
+package io.github.jonasrutishauser.cdi.features.deployment;
+
+interface NotAFeature {
+    CharSequence test();
+}

--- a/cdi-features/src/main/java/io/github/jonasrutishauser/cdi/features/NoSelectedFeatureException.java
+++ b/cdi-features/src/main/java/io/github/jonasrutishauser/cdi/features/NoSelectedFeatureException.java
@@ -1,5 +1,8 @@
 package io.github.jonasrutishauser.cdi.features;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
 import jakarta.enterprise.context.spi.Contextual;
 import jakarta.enterprise.inject.spi.BeanAttributes;
 
@@ -15,11 +18,14 @@ public class NoSelectedFeatureException extends IllegalStateException {
     }
 
     private static String getMessage(Contextual<?> contextual) {
-        Object description = contextual instanceof BeanAttributes
-                ? ((BeanAttributes<?>) contextual).getTypes().stream().filter(t -> !Object.class.equals(t)).findFirst()
-                        .orElse(Object.class)
+        Object description = contextual instanceof BeanAttributes ? getType((BeanAttributes<?>) contextual)
                 : contextual;
         return "No selected feature for " + description;
+    }
+
+    public static Type getType(BeanAttributes<?> contextual) {
+        return contextual.getTypes().stream().reduce(Object.class,
+                (a, b) -> Object.class.equals(a) || b instanceof ParameterizedType ? b : a);
     }
 
     public Contextual<?> getContextual() {

--- a/cdi-features/src/main/java/io/github/jonasrutishauser/cdi/features/impl/FeatureCreator.java
+++ b/cdi-features/src/main/java/io/github/jonasrutishauser/cdi/features/impl/FeatureCreator.java
@@ -62,7 +62,7 @@ public class FeatureCreator implements SyntheticBeanCreator<Object>  {
             } else if (isDefined(feature.propertyKey())) {
                 selector = lookup.getReference(ConfigurationSelector.class);
             } else {
-                selector = (Selector) () -> ((Selector) instance.getValue().get()).selected();
+                selector = ctx -> ((Selector) instance.getValue().get()).selected(ctx);
             }
             @SuppressWarnings("unchecked") // is checked by the extension
             ContextualSelector<? super T> contextualSelector = (ContextualSelector<? super T>) selector;

--- a/cdi-features/src/main/java/io/github/jonasrutishauser/cdi/features/impl/FeatureInstances.java
+++ b/cdi-features/src/main/java/io/github/jonasrutishauser/cdi/features/impl/FeatureInstances.java
@@ -1,6 +1,7 @@
 package io.github.jonasrutishauser.cdi.features.impl;
 
-import java.lang.reflect.Type;
+import static io.github.jonasrutishauser.cdi.features.NoSelectedFeatureException.getType;
+
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -11,7 +12,6 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import io.github.jonasrutishauser.cdi.features.ContextualSelector;
 import io.github.jonasrutishauser.cdi.features.ContextualSelector.Context;
 import io.github.jonasrutishauser.cdi.features.Feature;
-import io.github.jonasrutishauser.cdi.features.Selector;
 import io.github.jonasrutishauser.cdi.features.impl.Cache.Selection;
 import jakarta.enterprise.context.spi.Contextual;
 import jakarta.enterprise.inject.spi.Bean;
@@ -52,9 +52,6 @@ class FeatureInstances<T> {
             if (selector == null) {
                 return Selection.REMAINING;
             }
-            if (selector instanceof Selector s) {
-                return Selection.of(s.selected());
-            }
             return Selection.of(selector.selected(new Context<T>() {
                 @Override
                 @SuppressWarnings("unchecked")
@@ -81,8 +78,7 @@ class FeatureInstances<T> {
             if (property.contains("${type}")) {
                 String type = "<undefined>";
                 if (contextual instanceof BeanAttributes) {
-                    type = ((BeanAttributes<?>) contextual).getTypes().stream().filter(t -> !Object.class.equals(t))
-                            .findAny().map(Type::getTypeName).orElse(type);
+                    type = getType((BeanAttributes<?>) contextual).getTypeName();
                 }
                 property = property.replace("${type}", type);
             }

--- a/cdi-features/src/main/java/io/github/jonasrutishauser/cdi/features/impl/FeaturesBuildCompatibleExtension.java
+++ b/cdi-features/src/main/java/io/github/jonasrutishauser/cdi/features/impl/FeaturesBuildCompatibleExtension.java
@@ -266,12 +266,16 @@ public class FeaturesBuildCompatibleExtension implements BuildCompatibleExtensio
         Map<Type, Set<BeanInfo>> features = new HashMap<>();
         Set<Type> excludedTypes = new HashSet<>();
         excludedTypes.add(types.of(Object.class));
-        excludedTypes.add(types.of(ContextualSelector.class));
+        Type contextualSelectorType = types.of(ContextualSelector.class);
+        excludedTypes.add(contextualSelectorType);
         excludedTypes.add(types.of(Selector.class));
         excludedTypes.add(types.of(ThrowableSelector.class));
         for (BeanInfo featureBean : featureBeans) {
             for (Type type : featureBean.types()) {
-                if (!excludedTypes.contains(type) && !typesWithDefaultScopedBeans.contains(type)) {
+                if (!excludedTypes.contains(type)
+                        && !(type.isParameterizedType()
+                                && contextualSelectorType.equals(type.asParameterizedType().genericClass()))
+                        && !typesWithDefaultScopedBeans.contains(type)) {
                     features.computeIfAbsent(type, t -> new HashSet<>()).add(featureBean);
                 }
             }

--- a/cdi-features/src/main/java/io/github/jonasrutishauser/cdi/features/impl/FeaturesExtension.java
+++ b/cdi-features/src/main/java/io/github/jonasrutishauser/cdi/features/impl/FeaturesExtension.java
@@ -148,8 +148,10 @@ public class FeaturesExtension implements Extension {
         Map<Type, Set<Bean<?>>> features = new HashMap<>();
         for (Bean<?> featureBean : featureBeans) {
             for (Type type : featureBean.getTypes()) {
-                if (!Object.class.equals(type) && !ContextualSelector.class.equals(type) && !Selector.class.equals(type)
-                        && !ThrowableSelector.class.equals(type)) {
+                if (!Object.class.equals(type) && !ContextualSelector.class.equals(type)
+                        && !(type instanceof ParameterizedType parametrizedType
+                                && ContextualSelector.class.equals(parametrizedType.getRawType()))
+                        && !Selector.class.equals(type) && !ThrowableSelector.class.equals(type)) {
                     features.computeIfAbsent(type, t -> new HashSet<>()).add(featureBean);
                 }
             }


### PR DESCRIPTION
- Generated TypeLiteral in Quarkus was wrong if more than one parameterized type variant exists
- ContextualSelector type is not always correctly excluded from the types of a feature