### PR TITLE
Allow to use interceptor instead of a scope (not merged)

### DIFF
--- a/cdi-features-deployment/pom.xml
+++ b/cdi-features-deployment/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>io.github.jonasrutishauser</groupId>
 		<artifactId>cdi-features-parent</artifactId>
-		<version>1.0.1-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>cdi-features-deployment</artifactId>

--- a/cdi-features-ee9-test/pom.xml
+++ b/cdi-features-ee9-test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>io.github.jonasrutishauser</groupId>
 		<artifactId>cdi-features-parent</artifactId>
-		<version>1.0.1-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>cdi-features-ee9-test</artifactId>

--- a/cdi-features/pom.xml
+++ b/cdi-features/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>io.github.jonasrutishauser</groupId>
 		<artifactId>cdi-features-parent</artifactId>
-		<version>1.0.1-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>cdi-features</artifactId>
@@ -45,7 +45,7 @@
 		<dependency>
 			<groupId>org.jboss.weld</groupId>
 			<artifactId>weld-junit5</artifactId>
-			<version>4.0.5.Final</version>
+			<version>5.0.1.Final</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/cdi-features/src/main/java/io/github/jonasrutishauser/cdi/features/impl/FeatureInstances.java
+++ b/cdi-features/src/main/java/io/github/jonasrutishauser/cdi/features/impl/FeatureInstances.java
@@ -18,7 +18,7 @@ import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.BeanAttributes;
 
 class FeatureInstances<T> {
-    private final Map<Bean<? extends T>, Supplier<T>> instances;
+    protected final Map<Bean<? extends T>, Supplier<T>> instances;
     private final Map<Bean<? extends T>, ContextualSelector<? super T>> selectors;
     private final Cache cache;
 
@@ -33,7 +33,7 @@ class FeatureInstances<T> {
         return instances.get(selectedBean(contextual)).get();
     }
 
-    private synchronized Bean<?> selectedBean(Contextual<T> contextual) {
+    protected synchronized Bean<?> selectedBean(Contextual<T> contextual) {
         return cache.compute(contextual, selectors.keySet(), this::isSelected,
                 bean -> cacheDurationInMillis(contextual, bean));
     }

--- a/cdi-features/src/main/java/io/github/jonasrutishauser/cdi/features/impl/FeatureInterceptor.java
+++ b/cdi-features/src/main/java/io/github/jonasrutishauser/cdi/features/impl/FeatureInterceptor.java
@@ -1,0 +1,39 @@
+package io.github.jonasrutishauser.cdi.features.impl;
+
+import static jakarta.interceptor.Interceptor.Priority.PLATFORM_BEFORE;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.Intercepted;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.inject.Inject;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+@Priority(PLATFORM_BEFORE - 900)
+@Interceptor
+@FeatureSelector
+class FeatureInterceptor {
+
+    private final Bean<?> targetBean;
+    private FeatureInvoker<?> invoker;
+
+    @Inject
+    FeatureInterceptor(@Intercepted Bean<?> targetBean) {
+        this.targetBean = targetBean;
+    }
+
+    Bean<?> getTargetBean() {
+        return targetBean;
+    }
+
+    <T> void setInvoker(FeatureInvoker<?> invoker) {
+        this.invoker = invoker;
+    }
+
+    @AroundInvoke
+    Object intercept(InvocationContext context) throws Throwable {
+        return invoker.invoke(context.getMethod(), context.getParameters());
+    }
+
+}

--- a/cdi-features/src/main/java/io/github/jonasrutishauser/cdi/features/impl/FeatureInterceptor.java
+++ b/cdi-features/src/main/java/io/github/jonasrutishauser/cdi/features/impl/FeatureInterceptor.java
@@ -27,7 +27,7 @@ class FeatureInterceptor {
         return targetBean;
     }
 
-    <T> void setInvoker(FeatureInvoker<?> invoker) {
+    void setInvoker(FeatureInvoker<?> invoker) {
         this.invoker = invoker;
     }
 

--- a/cdi-features/src/main/java/io/github/jonasrutishauser/cdi/features/impl/FeatureInvoker.java
+++ b/cdi-features/src/main/java/io/github/jonasrutishauser/cdi/features/impl/FeatureInvoker.java
@@ -20,8 +20,8 @@ class FeatureInvoker<T> extends FeatureInstances<T> {
             Map<Bean<? extends T>, ContextualSelector<? super T>> selectors, Cache cache) {
         super(instances, selectors, cache);
         this.targetBean = targetBean;
-        Type type = getType(targetBean);
-        this.type = (Class<?>) (type instanceof Class ? type : ((ParameterizedType) type).getRawType());
+        Type targetType = getType(targetBean);
+        this.type = (Class<?>) (targetType instanceof Class ? targetType : ((ParameterizedType) targetType).getRawType());
     }
 
     public Object invoke(Method method, Object[] parameters) throws Throwable {

--- a/cdi-features/src/main/java/io/github/jonasrutishauser/cdi/features/impl/FeatureInvoker.java
+++ b/cdi-features/src/main/java/io/github/jonasrutishauser/cdi/features/impl/FeatureInvoker.java
@@ -1,0 +1,71 @@
+package io.github.jonasrutishauser.cdi.features.impl;
+
+import static io.github.jonasrutishauser.cdi.features.NoSelectedFeatureException.getType;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import io.github.jonasrutishauser.cdi.features.ContextualSelector;
+import jakarta.enterprise.inject.spi.Bean;
+
+class FeatureInvoker<T> extends FeatureInstances<T> {
+    protected final Bean<T> targetBean;
+    private final Class<?> type;
+
+    public FeatureInvoker(Bean<T> targetBean, Map<Bean<? extends T>, Supplier<T>> instances,
+            Map<Bean<? extends T>, ContextualSelector<? super T>> selectors, Cache cache) {
+        super(instances, selectors, cache);
+        this.targetBean = targetBean;
+        Type type = getType(targetBean);
+        this.type = (Class<?>) (type instanceof Class ? type : ((ParameterizedType) type).getRawType());
+    }
+
+    public Object invoke(Method method, Object[] parameters) throws Throwable {
+        Bean<?> selectedBean = selectedBean(targetBean);
+        return invoke(method, parameters, selectedBean);
+    }
+
+    protected Object invoke(Method method, Object[] parameters, Bean<?> selectedBean) throws Throwable {
+        Method resolvedMethod = map(method);
+        resolvedMethod.setAccessible(true);
+        try {
+            return resolvedMethod.invoke(instances.get(selectedBean).get(), parameters);
+        } catch (InvocationTargetException e) {
+            throw e.getCause();
+        }
+    }
+
+    private Method map(Method method) {
+        if (method.getDeclaringClass().isAssignableFrom(type)) {
+            return method;
+        }
+        try {
+            return getDeclaredMethod(method, type);
+        } catch (NoSuchMethodException e) {
+            return method;
+        }
+    }
+
+    private Method getDeclaredMethod(Method method, Class<?> clazz) throws NoSuchMethodException {
+        try {
+            return clazz.getDeclaredMethod(method.getName(), method.getParameterTypes());
+        } catch (NoSuchMethodException e) {
+            // continue searching in superclasses
+        }
+        for (Class<?> iface : clazz.getInterfaces()) {
+            try {
+                return getDeclaredMethod(method, iface);
+            } catch (NoSuchMethodException e) {
+                // continue searching in interfaces
+            }
+        }
+        if (clazz.getSuperclass() != null) {
+            return getDeclaredMethod(method, clazz.getSuperclass());
+        }
+        throw new NoSuchMethodException("No method found: " + method.getName() + " in " + clazz);
+    }
+}

--- a/cdi-features/src/main/java/io/github/jonasrutishauser/cdi/features/impl/FeatureInvokerInvoker.java
+++ b/cdi-features/src/main/java/io/github/jonasrutishauser/cdi/features/impl/FeatureInvokerInvoker.java
@@ -1,0 +1,42 @@
+package io.github.jonasrutishauser.cdi.features.impl;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import io.github.jonasrutishauser.cdi.features.ContextualSelector;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.invoke.Invoker;
+
+public class FeatureInvokerInvoker<T> extends FeatureInvoker<T> {
+
+    private Map<Bean<?>, Map<Method, ? extends Invoker<?, ?>>> invokers;
+
+    public FeatureInvokerInvoker(Bean<T> targetBean, Map<Bean<? extends T>, Supplier<T>> instances,
+            Map<Bean<? extends T>, ContextualSelector<? super T>> selectors, Cache cache,
+            Map<Bean<?>, Map<Method, ? extends Invoker<?, ?>>> invokers) {
+        super(targetBean, instances, selectors, cache);
+        this.invokers = invokers;
+    }
+
+    @Override
+    protected Object invoke(Method method, Object[] parameters, Bean<?> selectedBean) throws Throwable {
+        @SuppressWarnings("unchecked")
+        Map<Method, Invoker<T, ?>> selectedInvokers = (Map<Method, Invoker<T, ?>>) invokers.get(selectedBean);
+        if (selectedInvokers != null) {
+            Invoker<T, ?> invoker = selectedInvokers.get(method);
+            if (invoker == null) {
+                invoker = selectedInvokers.entrySet().stream() //
+                        .filter(entry -> entry.getKey().getName().equals(method.getName()) //
+                                && Arrays.equals(entry.getKey().getParameterTypes(), method.getParameterTypes())) //
+                        .map(Map.Entry::getValue) //
+                        .findFirst() //
+                        .orElseThrow(() -> new NoSuchMethodException("No invoker found for method: " + method));
+            }
+            return invoker.invoke(instances.get(selectedBean).get(), parameters);
+        }
+        return super.invoke(method, parameters, selectedBean);
+    }
+
+}

--- a/cdi-features/src/main/java/io/github/jonasrutishauser/cdi/features/impl/FeatureSelector.java
+++ b/cdi-features/src/main/java/io/github/jonasrutishauser/cdi/features/impl/FeatureSelector.java
@@ -1,0 +1,21 @@
+package io.github.jonasrutishauser.cdi.features.impl;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.interceptor.InterceptorBinding;
+
+@Target(TYPE)
+@Retention(RUNTIME)
+@InterceptorBinding
+@interface FeatureSelector {
+    public final static class Literal extends AnnotationLiteral<FeatureSelector> implements FeatureSelector {
+        public static final Literal INSTANCE = new Literal();
+
+        private static final long serialVersionUID = 1L;
+    }
+}

--- a/cdi-features/src/main/java/io/github/jonasrutishauser/cdi/features/impl/FeatureSelector.java
+++ b/cdi-features/src/main/java/io/github/jonasrutishauser/cdi/features/impl/FeatureSelector.java
@@ -13,7 +13,7 @@ import jakarta.interceptor.InterceptorBinding;
 @Retention(RUNTIME)
 @InterceptorBinding
 @interface FeatureSelector {
-    public final static class Literal extends AnnotationLiteral<FeatureSelector> implements FeatureSelector {
+    public static final class Literal extends AnnotationLiteral<FeatureSelector> implements FeatureSelector {
         public static final Literal INSTANCE = new Literal();
 
         private static final long serialVersionUID = 1L;

--- a/cdi-features/src/main/java/io/github/jonasrutishauser/cdi/features/impl/FeaturesExtension.java
+++ b/cdi-features/src/main/java/io/github/jonasrutishauser/cdi/features/impl/FeaturesExtension.java
@@ -7,6 +7,7 @@ import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.HashMap;
@@ -15,6 +16,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -32,7 +34,14 @@ import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.BeforeBeanDiscovery;
 import jakarta.enterprise.inject.spi.BeforeShutdown;
 import jakarta.enterprise.inject.spi.Extension;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.enterprise.inject.spi.InjectionTarget;
+import jakarta.enterprise.inject.spi.InterceptionFactory;
 import jakarta.enterprise.inject.spi.ProcessBean;
+import jakarta.enterprise.inject.spi.ProcessInjectionTarget;
+import jakarta.enterprise.inject.spi.ProcessManagedBean;
+import jakarta.enterprise.inject.spi.configurator.BeanConfigurator;
+import jakarta.enterprise.invoke.Invoker;
 import jakarta.enterprise.util.TypeLiteral;
 
 public class FeaturesExtension implements Extension {
@@ -41,9 +50,21 @@ public class FeaturesExtension implements Extension {
         private static final long serialVersionUID = 1L;
     }.getType();
 
+    private final FeatureInvokerFactory invokerFactory = createInvokerFactory();
+
+    private FeatureInvokerFactory createInvokerFactory() {
+        try {
+            return new FeatureInvokerInvokerFactory();
+        } catch (NoClassDefFoundError e) {
+            return new FeatureInvokerFactory();
+        }
+    }
+
     private final FeatureContext context = new FeatureContext();
 
     private final Set<Bean<?>> featureBeans = new HashSet<>();
+
+    private final boolean useInterceptor = Boolean.getBoolean("io.github.jonasrutishauser.cdi.features.useInterceptor");
 
     private boolean mpConfigAvailable;
 
@@ -67,7 +88,46 @@ public class FeaturesExtension implements Extension {
         if (feature.isPresent()) {
             validate(feature.get(), bean.getBean(), beanManager, bean::addDefinitionError);
             featureBeans.add(bean.getBean());
+            if (useInterceptor) {
+                invokerFactory.processFeatureBean(bean);
+            }
         }
+    }
+
+    void configureFeatureInvoker(@Observes ProcessInjectionTarget<FeatureInterceptor> event, BeanManager beanManager) {
+        InjectionTarget<FeatureInterceptor> delegate = event.getInjectionTarget();
+        event.setInjectionTarget(new InjectionTarget<FeatureInterceptor>() {
+            @Override
+            public void inject(FeatureInterceptor instance, CreationalContext<FeatureInterceptor> ctx) {
+                delegate.inject(instance, ctx);
+                instance.setInvoker(invokerFactory.createInvoker(ctx, instance.getTargetBean(), beanManager));
+            }
+
+            @Override
+            public void postConstruct(FeatureInterceptor instance) {
+                delegate.postConstruct(instance);
+            }
+
+            @Override
+            public void preDestroy(FeatureInterceptor instance) {
+                delegate.preDestroy(instance);
+            }
+
+            @Override
+            public FeatureInterceptor produce(CreationalContext<FeatureInterceptor> ctx) {
+                return delegate.produce(ctx);
+            }
+
+            @Override
+            public void dispose(FeatureInterceptor instance) {
+                delegate.dispose(instance);
+            }
+
+            @Override
+            public Set<InjectionPoint> getInjectionPoints() {
+                return delegate.getInjectionPoints();
+            }
+        });
     }
 
     private void validate(Feature feature, Bean<?> bean, BeanManager beanManager, Consumer<Throwable> definitionError) {
@@ -136,10 +196,15 @@ public class FeaturesExtension implements Extension {
     void registerFeatureSelectorBeans(@Priority(LIBRARY_AFTER + 500) @Observes AfterBeanDiscovery abd, BeanManager beanManager) {
         for (Entry<Type, Set<Bean<?>>> feature : getFeatures().entrySet()) {
             if (beanManager.getBeans(feature.getKey()).isEmpty()) {
-                abd.addBean() //
-                        .types(feature.getKey()) //
-                        .scope(FeatureScoped.class) //
-                        .createWith(ctx -> createDummy(beanManager, feature.getKey(), ctx, feature.getValue()));
+                BeanConfigurator<Object> configurator = abd.addBean().types(feature.getKey());
+                if (useInterceptor) {
+                    configurator.createWith(
+                            ctx -> createIntercepted(beanManager, feature.getKey(), ctx, feature.getValue()));
+                } else {
+                    configurator //
+                            .scope(FeatureScoped.class) //
+                            .createWith(ctx -> createDummy(beanManager, feature.getKey(), ctx, feature.getValue()));
+                }
             }
         }
     }
@@ -159,6 +224,20 @@ public class FeaturesExtension implements Extension {
         return features;
     }
 
+    private <T> T createIntercepted(BeanManager beanManager, Type type, CreationalContext<Object> ctx,
+            Set<Bean<? extends T>> value) {
+        @SuppressWarnings("unchecked")
+        Bean<T> ownBean = (Bean<T>) beanManager.resolve(beanManager.getBeans(type));
+        invokerFactory.addInstanceFactory(ownBean, creationContext -> getFeatureInstances(beanManager, type, creationContext, value));
+        // register target beans
+        @SuppressWarnings("unchecked")
+        InterceptionFactory<T> interceptionFactory = (InterceptionFactory<T>) beanManager.createInterceptionFactory(ctx,
+                value.stream().filter(invokerFactory::isManagedBean).map(Bean::getBeanClass).map(Class.class::cast)
+                        .findFirst().orElseGet(() -> toClass(type)));
+        interceptionFactory.configure().add(FeatureSelector.Literal.INSTANCE);
+        return interceptionFactory.createInterceptedInstance(null);
+    }
+
     private <T> T createDummy(BeanManager beanManager, Type type, CreationalContext<Object> ctx,
             Set<Bean<? extends T>> features) {
         Map<Bean<? extends T>, Supplier<T>> instances = getFeatureInstances(beanManager, type, ctx, features);
@@ -169,13 +248,13 @@ public class FeaturesExtension implements Extension {
         return instances.values().iterator().next().get();
     }
 
-    private Cache getCache(BeanManager beanManager, CreationalContext<Object> ctx) {
+    private static Cache getCache(BeanManager beanManager, CreationalContext<?> ctx) {
         return (Cache) beanManager.getReference(beanManager.resolve(beanManager.getBeans(Cache.class)), Cache.class,
                 ctx);
     }
 
     private static <T> Map<Bean<? extends T>, Supplier<T>> getFeatureInstances(BeanManager beanManager, Type type,
-            CreationalContext<Object> ctx, Set<Bean<? extends T>> features) {
+            CreationalContext<?> ctx, Set<Bean<? extends T>> features) {
         return features.stream().collect(toMap(identity(), bean -> {
             @SuppressWarnings("unchecked")
             T instance = (T) beanManager.getReference(bean, type, ctx);
@@ -183,8 +262,8 @@ public class FeaturesExtension implements Extension {
         }));
     }
 
-    private static <T> Map<Bean<? extends T>, ContextualSelector<? super T>> getSelectors(BeanManager beanManager, CreationalContext<Object> ctx,
-            Map<Bean<? extends T>, Supplier<T>> instances) {
+    private static <T> Map<Bean<? extends T>, ContextualSelector<? super T>> getSelectors(BeanManager beanManager,
+            CreationalContext<?> ctx, Map<Bean<? extends T>, Supplier<T>> instances) {
         Map<Bean<? extends T>, ContextualSelector<? super T>> selectors = new HashMap<>();
         for (Entry<Bean<? extends T>, Supplier<T>> instance : instances.entrySet()) {
             Feature feature = feature(instance.getKey()).orElseThrow();
@@ -242,6 +321,71 @@ public class FeaturesExtension implements Extension {
 
     void stopContext(@Observes BeforeShutdown bs) {
         context.stop();
+    }
+
+    @FunctionalInterface
+    private interface InstancesFactory<T> {
+        Map<Bean<? extends T>, Supplier<T>> create(CreationalContext<?> ctx);
+    }
+
+    private static class FeatureInvokerFactory {
+        private Map<Bean<?>, InstancesFactory<?>> instancesFactory = new ConcurrentHashMap<>();
+        private Set<Bean<?>> managedBeans = ConcurrentHashMap.newKeySet();
+
+        public <T> void processFeatureBean(ProcessBean<T> event) {
+            if (event instanceof ProcessManagedBean<T>) {
+                managedBeans.add(event.getBean());
+            }
+        }
+
+        public boolean isManagedBean(Bean<?> bean) {
+            return managedBeans.contains(bean);
+        }
+
+        public <T> void addInstanceFactory(Bean<T> bean, InstancesFactory<T> factory) {
+            instancesFactory.putIfAbsent(bean, factory);
+        }
+
+        public <T> FeatureInvoker<T> createInvoker(CreationalContext<FeatureInterceptor> ctx, Bean<T> targetBean,
+                BeanManager beanManager) {
+            Map<Bean<? extends T>, Supplier<T>> instances = getInstances(ctx, targetBean);
+            return new FeatureInvoker<>(targetBean, instances, getSelectors(beanManager, ctx, instances),
+                    getCache(beanManager, ctx));
+        }
+
+        @SuppressWarnings("unchecked")
+        protected <T> Map<Bean<? extends T>, Supplier<T>> getInstances(CreationalContext<FeatureInterceptor> ctx,
+                Bean<T> targetBean) {
+            return ((InstancesFactory<T>) instancesFactory.get(targetBean)).create(ctx);
+        }
+    }
+
+    private static class FeatureInvokerInvokerFactory extends FeatureInvokerFactory {
+        private Map<Bean<?>, Map<Method, ? extends Invoker<?, ?>>> invokers = new HashMap<>();
+
+        public FeatureInvokerInvokerFactory() {
+            Invoker.class.getName(); // ensure that the Invoker class is available
+        }
+
+        @Override
+        public <T> void processFeatureBean(ProcessBean<T> event) {
+            super.processFeatureBean(event);
+            if (event instanceof ProcessManagedBean<T> processManagedBean) {
+                Map<Method, Invoker<?, ?>> beanInvokers = new ConcurrentHashMap<>();
+                processManagedBean.getAnnotatedBeanClass().getMethods().stream().filter(method -> !method.isStatic())
+                        .forEach(method -> beanInvokers.put(method.getJavaMember(),
+                                processManagedBean.createInvoker(method).build()));
+                invokers.put(processManagedBean.getBean(), beanInvokers);
+            }
+        }
+
+        @Override
+        public <T> FeatureInvoker<T> createInvoker(CreationalContext<FeatureInterceptor> ctx, Bean<T> targetBean,
+                BeanManager beanManager) {
+            Map<Bean<? extends T>, Supplier<T>> instances = getInstances(ctx, targetBean);
+            return new FeatureInvokerInvoker<>(targetBean, instances, getSelectors(beanManager, ctx, instances),
+                    getCache(beanManager, ctx), invokers);
+        }
     }
 
 }

--- a/cdi-features/src/test/java/io/github/jonasrutishauser/cdi/features/AbstractIT.java
+++ b/cdi-features/src/test/java/io/github/jonasrutishauser/cdi/features/AbstractIT.java
@@ -19,6 +19,7 @@ import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.Produces;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.util.TypeLiteral;
 import jakarta.inject.Inject;
@@ -313,20 +314,22 @@ public abstract class AbstractIT {
         }
     }
 
-    @ApplicationScoped
-    @Feature(propertyKey = "feature", propertyValue = "3", cache = @Cache(durationMillis = 0, durationMillisProperty = "not.defined.property"))
-    static class SampleFeature3 implements SampleFeature {
-        SampleFeature3() {
-        }
+    @Dependent
+    static class SampleFeature3 {
+
+        private final Config config;
 
         @Inject
-        SampleFeature3(Config config) {
-            config.setFeature3Created();
+        public SampleFeature3(Config config) {
+            this.config = config;
         }
 
-        @Override
-        public String test() {
-            return "SampleFeature3";
+        @ApplicationScoped
+        @Feature(propertyKey = "feature", propertyValue = "3", cache = @Cache(durationMillis = 0, durationMillisProperty = "not.defined.property"))
+        @Produces
+        SampleFeature create() {
+            config.setFeature3Created();
+            return () -> "SampleFeature3";
         }
     }
 

--- a/cdi-features/src/test/java/io/github/jonasrutishauser/cdi/features/WeldUseInterceptorIT.java
+++ b/cdi-features/src/test/java/io/github/jonasrutishauser/cdi/features/WeldUseInterceptorIT.java
@@ -37,7 +37,7 @@ class WeldUseInterceptorIT extends AbstractIT {
     }
 
     @RepeatedTest(3)
-    public void delegatesScope() {
+    void delegatesScope() {
         AlwaysFeature.counter.set(0); // reset counter
         @SuppressWarnings("serial")
         Instance<GenericSampleFeature<StringBuffer>> select = instance.select(new TypeLiteral<GenericSampleFeature<StringBuffer>>() {});

--- a/cdi-features/src/test/java/io/github/jonasrutishauser/cdi/features/WeldUseInterceptorIT.java
+++ b/cdi-features/src/test/java/io/github/jonasrutishauser/cdi/features/WeldUseInterceptorIT.java
@@ -1,15 +1,22 @@
 package io.github.jonasrutishauser.cdi.features;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.jboss.weld.junit5.EnableWeld;
 import org.jboss.weld.junit5.WeldInitiator;
 import org.jboss.weld.junit5.WeldSetup;
 import org.jboss.weld.lite.extension.translator.BuildServicesImpl;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junitpioneer.jupiter.SetSystemProperty;
 
+import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.build.compatible.spi.BuildServicesResolver;
+import jakarta.enterprise.util.TypeLiteral;
 
 @EnableWeld
-class WeldIT extends AbstractIT {
+@SetSystemProperty(key = "io.github.jonasrutishauser.cdi.features.useInterceptor", value = "true")
+class WeldUseInterceptorIT extends AbstractIT {
 
     @WeldSetup
     public WeldInitiator weld = WeldInitiator.performDefaultDiscovery();
@@ -27,6 +34,16 @@ class WeldIT extends AbstractIT {
         static void setWeldBuildServices() {
             BuildServicesResolver.setBuildServices(new BuildServicesImpl());
         }
+    }
+
+    @RepeatedTest(3)
+    public void delegatesScope() {
+        AlwaysFeature.counter.set(0); // reset counter
+        @SuppressWarnings("serial")
+        Instance<GenericSampleFeature<StringBuffer>> select = instance.select(new TypeLiteral<GenericSampleFeature<StringBuffer>>() {});
+
+        assertEquals("always 0", select.get().test().toString());
+        assertEquals("always 1", select.get().test().toString());
     }
 
 }

--- a/cdi-features/src/test/resources/META-INF/beans.xml
+++ b/cdi-features/src/test/resources/META-INF/beans.xml
@@ -3,4 +3,10 @@
 	xmlns="https://jakarta.ee/xml/ns/jakartaee"
 	xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
 	version="3.0" bean-discovery-mode="annotated">
+	<scan>
+		<exclude name="io.github.jonasrutishauser.cdi.features.impl.*"></exclude>
+		<exclude name="io.github.jonasrutishauser.cdi.features.WeldIT$Initializer">
+			<if-class-not-available name="jakarta.enterprise.inject.build.compatible.spi.BuildServices"/>
+		</exclude>
+	</scan>
 </beans>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 
 	<artifactId>cdi-features-parent</artifactId>
-	<version>1.0.1-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<url>${url}</url>


### PR DESCRIPTION
This way a `@Dependent` feature bean is dependent scoped of the injection point and not like an application scoped bean.

At the moment only CDI Full is supported.
An implementation for Quarkus should be possible, but not done yet.